### PR TITLE
Fixes the API error handling

### DIFF
--- a/pkg/description/descriptor_api.go
+++ b/pkg/description/descriptor_api.go
@@ -87,21 +87,17 @@ func (d *Descriptor) DescribePokemon(resource string) *response.ServiceResponse 
 	}
 
 	defer resp.Body.Close()
-	//due to relatively small response size reading respoonse without doing the buffered I/O (buffio)
+	//due to relatively small response size reading response without doing the buffered I/O (buffio)
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		log.Errorf("error reading http response for resource %s : %v", resource, err)
 		return response.NewError(err)
 	}
 
-	if resp.StatusCode >= 500 {
-		err := fmt.Errorf("internal server error (code: %d)", resp.StatusCode)
-		log.Errorf("error executing http request for the resource %s : %v", resource, err)
-		return response.NewErrorCode(resp.StatusCode, err)
-	} else if resp.StatusCode >= 400 {
-		err := fmt.Errorf("failed to retrieve pokemon resource %s (code: %d)", resource, resp.StatusCode)
-		log.Errorf("error executing http request for the resource %s : %v", resource, err)
-		return response.NewErrorCode(resp.StatusCode, err)
+	if resp.StatusCode >= 400 {
+		log.Errorf("error executing http request for the resource %s : %s", resource, string(body))
+		err := fmt.Errorf("failed to retrieve pokemon resource %s (code: %d)", resource, http.StatusNotFound)
+		return response.NewErrorCode(http.StatusNotFound, err)
 	}
 
 	var species speciesResponse

--- a/pkg/translation/translator_api.go
+++ b/pkg/translation/translator_api.go
@@ -49,7 +49,7 @@ type Translator struct {
 	APIKey string
 }
 
-// NewTranslator is factorry method to create the Translator instance
+// NewTranslator is factory method to create the Translator instance
 func NewTranslator() *Translator {
 	return &Translator{
 		client: &http.Client{},
@@ -100,9 +100,9 @@ func (t *Translator) Translate(text string) *response.ServiceResponse {
 	}
 
 	if resp.StatusCode >= 400 {
-		log.Error("error executing http request")
+		log.Errorf("error executing http request for funtranlation API")
 		t.logResponseError(body)
-		err = fmt.Errorf("internal server error (code: %d)", http.StatusInternalServerError)
+		err = fmt.Errorf("internal server error occurred (code: %d)", http.StatusInternalServerError)
 		return response.NewErrorCode(http.StatusInternalServerError, err)
 	}
 

--- a/pkg/translation/translator_api_test.go
+++ b/pkg/translation/translator_api_test.go
@@ -62,7 +62,7 @@ func Test_translate_text_error(t *testing.T) {
 		t.Errorf("expecting an error code %d but got none : %d \n", wantErrorCode, got.ErrorCode)
 	}
 
-	wantErrorMessage := "internal server error (code: 500)"
+	wantErrorMessage := "internal server error occurred (code: 500)"
 	if got.Error.Error() != wantErrorMessage {
 		t.Errorf("expecting an error %s but got %s \n", wantErrorMessage, got.Error.Error())
 	}


### PR DESCRIPTION
This patch fixes the API error handling and returns the consistent error
codes for /pokemon API.

Fixes #13